### PR TITLE
Only require usearch for UPARSE and QIIME pipelines

### DIFF
--- a/Amplicon_analysis_pipeline.sh
+++ b/Amplicon_analysis_pipeline.sh
@@ -233,7 +233,10 @@ fi;
 
 #Path to Script's directory
 export DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd );
-		
+
+# Get pipeline name in uppercase
+PIPELINE_NAME=$(echo $PIPELINE | tr '[:lower:]' '[:upper:]')
+
 #Check for required programs in current environment
 #Report missing programs and exit if any are not installed/loaded
 REQUIRED_PROGRAMS="cutadapt
@@ -250,7 +253,7 @@ fasta_number.py
 blastall
 R"
 # Add usearch executables if using UPARSE pipeline
-if [[ "$(echo $PIPELINE | tr '[:lower:]' '[:upper:]')" == "UPARSE" ]] ; then
+if [[ "$PIPELINE_NAME" == "UPARSE" ]] ; then
     REQUIRED_PROGRAMS="$REQUIRED_PROGRAMS
 usearch8.0.1623_i86linux32
 usearch6.1.544_i86linux32"

--- a/Amplicon_analysis_pipeline.sh
+++ b/Amplicon_analysis_pipeline.sh
@@ -242,15 +242,19 @@ fastqc
 spades
 bioawk
 pandaseq
-usearch8.0.1623_i86linux32
 vsearch113
 ChimeraSlayer.pl
-usearch6.1.544_i86linux32
 print_qiime_config.py
 fasta-splitter.pl
 fasta_number.py
 blastall
 R"
+# Add usearch executables if using UPARSE pipeline
+if [[ "$(echo $PIPELINE | tr '[:lower:]' '[:upper:]')" == "UPARSE" ]] ; then
+    REQUIRED_PROGRAMS="$REQUIRED_PROGRAMS
+usearch8.0.1623_i86linux32
+usearch6.1.544_i86linux32"
+fi
 MISSING_PROGRAMS=
 for prog in $REQUIRED_PROGRAMS ; do
     echo -n "Checking for ${prog}..."

--- a/Amplicon_analysis_pipeline.sh
+++ b/Amplicon_analysis_pipeline.sh
@@ -252,12 +252,21 @@ fasta-splitter.pl
 fasta_number.py
 blastall
 R"
-# Add usearch executables if using UPARSE pipeline
-if [[ "$PIPELINE_NAME" == "UPARSE" ]] ; then
-    REQUIRED_PROGRAMS="$REQUIRED_PROGRAMS
-usearch8.0.1623_i86linux32
+# Require usearch executables for specific pipelines
+case "$PIPELINE_NAME" in
+    "UPARSE")
+	# UPARSE pipeline needs usearch 8.0.1623
+	REQUIRED_PROGRAMS="$REQUIRED_PROGRAMS
+usearch8.0.1623_i86linux32"
+	;;
+    "QIIME")
+	# UPARSE pipeline needs usearch 6.1.544
+	REQUIRED_PROGRAMS="$REQUIRED_PROGRAMS
 usearch6.1.544_i86linux32"
-fi
+	;;
+    *)
+	;;
+esac
 MISSING_PROGRAMS=
 for prog in $REQUIRED_PROGRAMS ; do
     echo -n "Checking for ${prog}..."

--- a/Amplicon_analysis_pipeline.sh
+++ b/Amplicon_analysis_pipeline.sh
@@ -493,15 +493,15 @@ set -e
 				exit 1;
 		fi;
 		# If -P is passed as "qiime" the script will use QIIME
-		if [[ "$PIPELINE" == "qiime" ]] || [[ "$PIPELINE" == "QIIME" ]] || [[ "$PIPELINE" == "Qiime" ]]; then		
+		if [[ "$PIPELINE_NAME" == "QIIME" ]]; then
 				source $DIR/QIIME.sh
 		
 		# If -P is passed as "uparse" the script will use UPARSE (Usearch 8.0)
-		elif [[ "$PIPELINE" == "UPARSE" ]] || [[ "$PIPELINE" == "uparse" ]] || [[ "$PIPELINE" == "Uparse" ]]; then
+		elif [[ "$PIPELINE_NAME" == "UPARSE" ]]; then
 				source $DIR/UPARSE.sh
 		
 		# If -P is passed as "vsearch" the script will use vsearch, a freely available programme (64-bit) almost identical to UPARSE		
-		elif  [[ "$PIPELINE" == "VSEARCH" ]] || [[ "$PIPELINE" == "vsearch" ]] || [[ "$PIPELINE" == "Vsearch" ]]; then	
+		elif  [[ "$PIPELINE_NAME" == "VSEARCH" ]]; then
 				source $DIR/VSEARCH.sh
 		
 		else

--- a/Amplicon_analysis_pipeline.sh
+++ b/Amplicon_analysis_pipeline.sh
@@ -487,28 +487,31 @@ set -e
 		fi
 
 ################################################################## SECOND_STEP ###################################################################
-		#Exit if no pipeline specified
-		if [ -z $PIPELINE ]; then
-				usage;
-				exit 1;
-		fi;
-		# If -P is passed as "qiime" the script will use QIIME
-		if [[ "$PIPELINE_NAME" == "QIIME" ]]; then
-				source $DIR/QIIME.sh
-		
-		# If -P is passed as "uparse" the script will use UPARSE (Usearch 8.0)
-		elif [[ "$PIPELINE_NAME" == "UPARSE" ]]; then
-				source $DIR/UPARSE.sh
-		
-		# If -P is passed as "vsearch" the script will use vsearch, a freely available programme (64-bit) almost identical to UPARSE		
-		elif  [[ "$PIPELINE_NAME" == "VSEARCH" ]]; then
-				source $DIR/VSEARCH.sh
-		
-		else
-				echo " -P $PIPELINE is not a valid option." >> $LOG;
-				usage;
-				exit 1;		
-		fi;
+		# Execute appropriate pipeline based on -P option
+		case "$PIPELINE_NAME" in
+		    "QIIME")
+			source $DIR/QIIME.sh
+			;;
+		    "UPARSE")
+			source $DIR/UPARSE.sh
+			;;
+		    "VSEARCH")
+			source $DIR/VSEARCH.sh
+			;;
+		    *)
+			# Unrecognised pipeline
+			if [ -z $PIPELINE ]; then
+			    #Exit if no pipeline specified
+			    usage
+			    exit 1
+			else
+			    #Invalid pipeline option
+			    echo " -P $PIPELINE is not a valid option." >> $LOG;
+			    usage;
+			    exit 1;
+			fi
+			;;
+		esac
 ################################################################ THIRD_STEP ####################################################################
 		source $DIR/THIRD_STEP.sh
 


### PR DESCRIPTION
Pull request which implements the following changes in `Amplicon_analysis.sh`:

* Only checks for the `usearch8.0.1623_i86linux32` executable if the `UPARSE` pipeline is selected;
* Only checks for the `usearch6.1.544_i86linux32` executable if the `QIIME` pipeline is selected.

Additional changes:

 * Set a new variable `PIPELINE_NAME`, which is an upper-cased copy of the `PIPELINE` (i.e. the string passed in via the `-P` option) and use this when determining which pipeline script to run (reduces the amount of code) (commit 201f905);
 * Use a `case` statement to replace the `if...elif...else` construct used for determining which pipeline script to run (commit 37bc347).

Let me know if there are any problems or objections to these changes and I'll make appropriate updates.