### PR TITLE
Update QIIME.sh to configure .qiime_config file correctly

### DIFF
--- a/QIIME.sh
+++ b/QIIME.sh
@@ -8,9 +8,9 @@ echo -e "QIIME pipeline started at $(date|awk '{print $4}') \nQIIME version 1.8.
 
 #Lets define the configuration of QIIME		
 if [[ -z $SILVA ]]; then
-		awk -v k=$DIR '{if (NR==12) $0="pynast_template_alignment_fp "k"/gg_13_8_otus/rep_set_aligned/97_otus.fasta"} {if (NR==23) $0="assign_taxonomy_reference_seqs_fp "k"/gg_13_8_otus/rep_set/97_otus.fasta"} {if (NR==24) $0="assign_taxonomy_id_to_taxonomy_fp "k"/gg_13_8_otus/taxonomy/97_otu_taxonomy.txt"} {print}' $DIR/Config_QIIME/.qiime_config > ~/.qiime_config ;
+		awk -v k=$$REF_DATA_PATH '{if (NR==12) $0="pynast_template_alignment_fp "k"/gg_13_8_otus/rep_set_aligned/97_otus.fasta"} {if (NR==23) $0="assign_taxonomy_reference_seqs_fp "k"/gg_13_8_otus/rep_set/97_otus.fasta"} {if (NR==24) $0="assign_taxonomy_id_to_taxonomy_fp "k"/gg_13_8_otus/taxonomy/97_otu_taxonomy.txt"} {print}' $DIR/Config_QIIME/.qiime_config > ~/.qiime_config ;
 else	
-		awk -v k=$DIR '{if (NR==12) $0="pynast_template_alignment_fp "k"/Silva/Silva119_release/core_alignment/core_Silva119_alignment.fna"} {if (NR==23) $0="assign_taxonomy_reference_seqs_fp "k"/Silva/Silva119_release/rep_set/97/Silva_119_rep_set97.fna"} {if (NR==24) $0="assign_taxonomy_id_to_taxonomy_fp "k"/Silva/Silva119_release/taxonomy/97/taxonomy_97_7_levels.txt"} {print}' $DIR/Config_QIIME/.qiime_config > ~/.qiime_config;
+		awk -v k=$REF_DATA_PATH '{if (NR==12) $0="pynast_template_alignment_fp "k"/Silva/Silva119_release/core_alignment/core_Silva119_alignment.fna"} {if (NR==23) $0="assign_taxonomy_reference_seqs_fp "k"/Silva/Silva119_release/rep_set/97/Silva_119_rep_set97.fna"} {if (NR==24) $0="assign_taxonomy_id_to_taxonomy_fp "k"/Silva/Silva119_release/taxonomy/97/taxonomy_97_7_levels.txt"} {print}' $DIR/Config_QIIME/.qiime_config > ~/.qiime_config;
 fi;
 				
 
@@ -72,7 +72,7 @@ else
 
 		if [[ ! -z $SILVA ]]; then
 				echo "ChimeraSlayer does not support the latest version of Silva db yet. For chimera detection Silva version 108 will be used." >> $LOG;
-				ALIGNED="$DIR/Silva/Silva_108_core_alignment/Silva_108_core_aligned_seqs.fasta"
+				ALIGNED="$REF_DATA_PATH/Silva/Silva_108_core_alignment/Silva_108_core_aligned_seqs.fasta"
 		fi;
 
 		# Create a parameter file for "pick_otus.py".rm if it already exists

--- a/QIIME.sh
+++ b/QIIME.sh
@@ -8,7 +8,7 @@ echo -e "QIIME pipeline started at $(date|awk '{print $4}') \nQIIME version 1.8.
 
 #Lets define the configuration of QIIME		
 if [[ -z $SILVA ]]; then
-		awk -v k=$$REF_DATA_PATH '{if (NR==12) $0="pynast_template_alignment_fp "k"/gg_13_8_otus/rep_set_aligned/97_otus.fasta"} {if (NR==23) $0="assign_taxonomy_reference_seqs_fp "k"/gg_13_8_otus/rep_set/97_otus.fasta"} {if (NR==24) $0="assign_taxonomy_id_to_taxonomy_fp "k"/gg_13_8_otus/taxonomy/97_otu_taxonomy.txt"} {print}' $DIR/Config_QIIME/.qiime_config > ~/.qiime_config ;
+		awk -v k=$REF_DATA_PATH '{if (NR==12) $0="pynast_template_alignment_fp "k"/gg_13_8_otus/rep_set_aligned/97_otus.fasta"} {if (NR==23) $0="assign_taxonomy_reference_seqs_fp "k"/gg_13_8_otus/rep_set/97_otus.fasta"} {if (NR==24) $0="assign_taxonomy_id_to_taxonomy_fp "k"/gg_13_8_otus/taxonomy/97_otu_taxonomy.txt"} {print}' $DIR/Config_QIIME/.qiime_config > ~/.qiime_config ;
 else	
 		awk -v k=$REF_DATA_PATH '{if (NR==12) $0="pynast_template_alignment_fp "k"/Silva/Silva119_release/core_alignment/core_Silva119_alignment.fna"} {if (NR==23) $0="assign_taxonomy_reference_seqs_fp "k"/Silva/Silva119_release/rep_set/97/Silva_119_rep_set97.fna"} {if (NR==24) $0="assign_taxonomy_id_to_taxonomy_fp "k"/Silva/Silva119_release/taxonomy/97/taxonomy_97_7_levels.txt"} {print}' $DIR/Config_QIIME/.qiime_config > ~/.qiime_config;
 fi;

--- a/QIIME.sh
+++ b/QIIME.sh
@@ -13,6 +13,8 @@ else
 		awk -v k=$REF_DATA_PATH '{if (NR==12) $0="pynast_template_alignment_fp "k"/Silva/Silva119_release/core_alignment/core_Silva119_alignment.fna"} {if (NR==23) $0="assign_taxonomy_reference_seqs_fp "k"/Silva/Silva119_release/rep_set/97/Silva_119_rep_set97.fna"} {if (NR==24) $0="assign_taxonomy_id_to_taxonomy_fp "k"/Silva/Silva119_release/taxonomy/97/taxonomy_97_7_levels.txt"} {print}' $DIR/Config_QIIME/.qiime_config > ~/.qiime_config;
 fi;
 				
+# Fix the path to the qiime_scripts_dir in the QIIME config file
+sed -i 's,\(qiime_scripts_dir\t\).*,\1'$(dirname $(which print_qiime_config.py))',g' ~/.qiime_config
 
 #Lets call the function to check the dimension of multiplexed/multiplexed_linearized.fasta files and store it in a variable
 check_dimension


### PR DESCRIPTION
Pull request makes two changes to the `QIIME.sh`script to correctly configure the `.qiime_config` file:

* Correctly set the parent directory for the reference databases when using the `-r` option of `Amplicon_analysis_pipeline.sh` (was broken);
* Correctly set the location of the `qiime_scripts_dir` (was previously hardcoded as `/opt/gridware/apps/gcc/qiime/1.8.0/bin`, which was broken on systems where the QIIME installation was in a different place - see e.g. https://github.com/pjbriggs/Amplicon_analysis-galaxy/issues/10).