### PR TITLE
Replace non-ascii double quotes with ascii versions

### DIFF
--- a/Amplicon_analysis_pipeline.sh
+++ b/Amplicon_analysis_pipeline.sh
@@ -156,7 +156,7 @@ export TREE=
 export REF_DATA_PATH=
 
 #Get the arguments
-while getopts “hg:G:q:l:O:L:1:P:Si:o:m:t:r:3” OPTION
+while getopts "hg:G:q:l:O:L:1:P:Si:o:m:t:r:3" OPTION
 do
      case $OPTION in
          h)


### PR DESCRIPTION
Replaces non-ASCII double quotation marks in `Amplicon_analysis_pipeline.sh` with ASCII equivalents.

I'm not sure if this makes a practical difference but seems safer/more portable.