### PR TITLE
Replace 'fasta_number.py' with home-grown 'relabel_fasta.py' utility

### DIFF
--- a/Amplicon_analysis_pipeline.sh
+++ b/Amplicon_analysis_pipeline.sh
@@ -254,7 +254,6 @@ vsearch113
 ChimeraSlayer.pl
 print_qiime_config.py
 fasta-splitter.pl
-fasta_number.py
 blastall
 R"
 # Require usearch executables for specific pipelines

--- a/README.md
+++ b/README.md
@@ -124,7 +124,6 @@ If you are using the programme on CSF load the following modules (you can copy a
 	module load apps/binapps/microbiomeutil/r20110519
 	module load apps/binapps/blast/legacy/2.2.26
 	module load apps/binapps/usearch/8.0.1623
-	module load apps/binapps/fasta_number/02jun2015
 	module load apps/binapps/fasta-splitter/0.2.4
 	module load apps/binapps/rdp_classifier/2.2
 	module load apps/gcc/R/3.2.0

--- a/UPARSE.sh
+++ b/UPARSE.sh
@@ -50,7 +50,7 @@ CHIM_REF=$(grep -E chimeras\|found $UPARSE_STDERR);
 echo "{$CHIM_REF}"|grep -v +|head -2|tail -1|awk 'END {print "Reference based chimera removal found : "$NF" Chimeras ("$(NF-3)" OTUs)"}'| sed 's/(//1;s/)//1'|sed 's/\r//g' >> $LOG;
 		
 # Label OTUs using UPARSE python script
-python $( which fasta_number.py) Multiplexed_files/Uparse_pipeline/multiplexed_linearized_dereplicated_mc2_repset_nonchimeras.fasta OTU_> Multiplexed_files/Uparse_pipeline/multiplexed_linearized_dereplicated_mc2_repset_nonchimeras_OTUs.fasta;
+python $DIR/relabel_fasta/relabel_fasta.py Multiplexed_files/Uparse_pipeline/multiplexed_linearized_dereplicated_mc2_repset_nonchimeras.fasta OTU_> Multiplexed_files/Uparse_pipeline/multiplexed_linearized_dereplicated_mc2_repset_nonchimeras_OTUs.fasta;
 
 # Map reads (including singletons) back to OTUs directly when possible. If the file is too big the script will use an alternative strategy from Dr Ijaz tutorial
 mkdir -p Uparse_OTU_tables;		

--- a/relabel_fasta/relabel_fasta.py
+++ b/relabel_fasta/relabel_fasta.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python
+
+DESCRIPTION = \
+"""Replace FASTA labels with new labels <PREFIX>1, <PREFIX>2,
+<PREFIX>3 ... (<PREFIX> is provided by the user via the command
+line).
+
+Can be used to label OTUs as OTU_1, OTU_2 etc.
+
+This reimplements the functionality of the fasta_number.py utility
+from https://drive5.com/python/fasta_number_py.html
+"""
+
+import argparse
+
+def relabel_fasta(fp,prefix,include_size=False):
+    """
+    Relabel sequence records in a FASTA file
+
+    Arguments:
+      fp (File): file-like object opened for reading
+        input FASTA data from
+      prefix (str): prefix to use in new labels
+      include_size (bool): if True then copy
+        'size=...' records into new labels (default
+        is not to copy the size)
+
+    Yields: updated lines from the input FASTA.
+    """
+    # Iterate over lines in file
+    nlabel = 0
+    for line in fp:
+        # Strip trailing newlines
+        line = line.rstrip('\n')
+        if not line:
+            # Skip blank lines
+            continue
+        elif line.startswith('>'):
+            # Deal with start of a sequence record
+            nlabel += 1
+            label = line[1:].strip()
+            if include_size:
+                # Extract size from the label
+                try:
+                    size = filter(
+                        lambda x: x.startswith("size="),
+                        label.split(';'))[0]
+                except Exception as ex:
+                    raise Exception("Couldn't locate 'size' in "
+                                    "label: %s" % label)
+                yield ">%s%d;%s" % (args.prefix,
+                                    nlabel,
+                                    size)
+            else:
+                yield ">%s%d" % (args.prefix,
+                                 nlabel)
+        else:
+            # Echo the line to output
+            yield line
+
+if __name__ == "__main__":
+    # Set up command line parser
+    p = argparse.ArgumentParser(description=DESCRIPTION)
+    p.add_argument("--needsize",
+                   action="store_true",
+                   help="include the size as part of the "
+                   "output label ('size=...' must be present "
+                   "in the input FASTA labels). Output labels "
+                   "will be '<PREFIX><NUMBER>;size=<SIZE>'")
+    p.add_argument("--nosize",
+                   action="store_true",
+                   help="don't include the size as part of "
+                   "the output label (this is the default)")
+    p.add_argument("fasta",
+                   metavar="FASTA",
+                   help="input FASTA file")
+    p.add_argument("prefix",
+                   metavar="PREFIX",
+                   help="prefix to use for labels in output")
+    # Process command line
+    args = p.parse_args()
+    # Relabel FASTA
+    with open(args.fasta,'rU') as fasta:
+        for line in relabel_fasta(fasta,
+                                  args.prefix,
+                                  include_size=args.needsize):
+            print line
+


### PR DESCRIPTION
This PR adds a new Python script `relabel_fasta.py` which reimplements the functionality of the `fasta_number.py`, and updates the pipeline scripts to use the new script in its place (removing the dependency on `fasta_number.py`).

The new script is in the `relabel_fasta` subdirectory (cf the `uc2otutab` utility); the changes only affect the `UPARSE.sh` script.