### PR TITLE
THIRD_STEP.sh: handle numbers with thousands-comma-separators (e.g. '…

### DIFF
--- a/THIRD_STEP.sh
+++ b/THIRD_STEP.sh
@@ -18,8 +18,8 @@ biom summarize-table -i $BIOM -o $RESULTS_PATH/table_summary.txt;
 #Check if there are samples with less than 5000 sequences. These will be excluded because it would be a problem for subsequent analyses
 #In case samples with <5K seqs are found a new OTU table will be made
 #Get a list of samples with more and less than 5000 sequences
-LESSFIVEK=$(tail -n+17 $RESULTS_PATH/table_summary.txt |awk -F ":" '{if ( $2 <= 5000) print $1"\t"$2 }'|sed 's/ //g');
-MOREFIVEK=$(tail -n+17 $RESULTS_PATH/table_summary.txt |awk -F ":" '{if ( $2 >= 5000) print $1 }'|sed 's/ //g');
+LESSFIVEK=$(tail -n+17 $RESULTS_PATH/table_summary.txt |sed 's/,//g'|awk -F ":" '{if ( $2 <= 5000) print $1"\t"$2 }'|sed 's/ //g');
+MOREFIVEK=$(tail -n+17 $RESULTS_PATH/table_summary.txt |sed 's/,//g'|awk -F ":" '{if ( $2 >= 5000) print $1 }'|sed 's/ //g');
 
 #If there are samples with less than 5000 sequences, filter them out from the OTU table for subsequent analyses
 if [[ -n $LESSFIVEK ]];then 
@@ -47,7 +47,7 @@ if [[ -n $LESSFIVEK ]];then
 fi;
 	
 #Extract the minimum depth to use in beta-diversity
-MINDEPTH=$(grep Min $RESULTS_PATH/table_summary.txt |awk -F " " '{print $2}'|awk -F "." '{print $1}');
+MINDEPTH=$(grep Min $RESULTS_PATH/table_summary.txt |sed 's/,//g'|awk -F " " '{print $2}'|awk -F "." '{print $1}');
 	
 #Beta-diversity analysis
 echo "beta_diversity_through_plots.py $(date|awk '{print $4}')" >> $LOG;


### PR DESCRIPTION
PR to address an issue encountered when testing the updated `Vsearch` pipeline installed using the installer script from the `amplicon_analysis_pipeline` Galaxy tool.

When using this version of the pipeline dependencies, numbers in the `table_summary.txt` file appear to include a comma separators to mark thousands. For example:

    ...
    Counts/sample detail:
    PsC-4.7: 147,822.000
    PsA-15.0: 170,527.000
    PsA-9.0: 297,024.000
    ...

The presence of these comma separators causes problems in the `THIRD_STEP.sh` script (e.g. when checking for samples with less or more than 5000 sequences). The changes update the code which parses these numbers, to remove any comma separators.